### PR TITLE
editアクションのレスポンス内容実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,8 +1,9 @@
 class PrototypesController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_prototype, only: [:edit, :update]
 
   def index
-    @prototypes = Prototype.includes(:user).order("created_at DESC")
+    @prototypes = Prototype.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -18,9 +19,28 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def show
+  end
+
+  def edit
+    redirect_to root_path if user_signed_in? && current_user.id != @prototype.user_id
+  end
+
+  def update
+    if @prototype.update(prototype_params)
+      redirect_to prototype_path(@prototype.id)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
+
   def prototype_params
     params.require(:prototype).permit(:prototype_name, :catchphrase, :concept, :image).merge(user_id: current_user.id)
   end
 
+  def set_prototype
+    @prototype = Prototype.find(params[:id])
+  end
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,7 +1,7 @@
 class Prototype < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  
+
   validates :prototype_name, presence: true
   validates :catchphrase, presence: true
   validates :concept, presence: true

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+      <%= render partial: 'form', locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "prototypes#index"
-  resources :prototypes, only: [:index, :new, :create]
+  resources :prototypes, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/test/models/prototype_test.rb
+++ b/test/models/prototype_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class PrototypeTest < ActiveSupport::TestCase
   # test "the truth" do


### PR DESCRIPTION
# Why

－プロトタイプを保存したユーザーが自身の投稿を編集できるようにするため

－プロトタイプを保存していないユーザーが自身以外の投稿を編集できないようにするため


# What

－以下の項目を実装しました。

・edit, updateアクションをコントローラーに設定
・editのHTMLの編集